### PR TITLE
Fix typo that caused a bug in Compare environments screen. …

### DIFF
--- a/src/views/compareEnv/CompareEnv.js
+++ b/src/views/compareEnv/CompareEnv.js
@@ -544,7 +544,7 @@ class CompareEnv extends Component {
       Array.isArray(this.props.compareEnv.envsDiff)
     ) {
       data = this.props.compareEnv.envsDiff
-        .filter(f => this.customFilter(f, this.props.compareEnv.inputFilte))
+        .filter(f => this.customFilter(f, this.props.compareEnv.inputFilter))
         .sort(this.sort);
     }
     let striped = false;


### PR DESCRIPTION


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>